### PR TITLE
Add command to restart hie from within Atom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 npm-debug.log
 node_modules
 package-lock.json
+.vscode

--- a/lib/ide-haskell-hie.js
+++ b/lib/ide-haskell-hie.js
@@ -1,81 +1,97 @@
 const childProcess = require('child_process');
 const os = require('os');
+const path = require('path');
 const { shell } = require('electron');
 const { AutoLanguageClient } = require('atom-languageclient');
 const { CompositeDisposable } = require('atom');
-const path = require('path');
 
 class HaskellLanguageClient extends AutoLanguageClient {
+
   getGrammarScopes() {
     return ['source.haskell', 'text.tex.latex.haskell']
   }
+
   getLanguageName() {
     return 'Haskell'
   }
+
   getServerName() {
     return 'hie'
   }
 
-  startServerProcess() {
-    return this.spawnServer()
+  /*
+   * `startServerProcess` will be called automatically for us by the
+   * LSP client, and is where the server will be launched from.
+   */
+  startServerProcess(projectPath) {
+    return this.spawnServer(projectPath)
   }
 
+  /*
+   * Restart the LSP (hie) server, notify the user, and clear the subscriptions.
+   */
   restartServer() {
     this.subscriptions.dispose();
-    atom.notifications.addInfo("HIE is being restarted!");
-    this.restartAllServers();
+    this.restartAllServers().then(() => {
+      atom.notifications.addInfo("HIE is has been restarted, and is currently initializing!");
+    }).catch(() => {
+      atom.notifications.addError("Something went wrong trying to restart HIE!");
+    });
   }
 
-  spawnServer() {
+  /*
+   * The core logic for starting the LSP server.
+   */
+  spawnServer(projectPath) {
     let hiePath = atom.config.get("ide-haskell-hie.hiePath"),
-      useHieWrapper = atom.config.get("ide-haskell-hie.useHieWrapper"),
+      processOptions = {},
+      args = [''];
+    const useHieWrapper = atom.config.get("ide-haskell-hie.useHieWrapper"),
       useCustomHieWrapper = atom.config.get("ide-haskell-hie.useCustomHieWrapper"),
       useCustomHieWrapperPath = atom.config.get("ide-haskell-hie.useCustomHieWrapperPath"),
       hieDebug = atom.config.get("ide-haskell-hie.isDebug"),
-      hieLoggingPath = atom.config.get("ide-haskell-hie.hieLoggingPath");
+      hieLoggingPath = atom.config.get("ide-haskell-hie.hieLoggingPath"),
+      pluginPath = atom.packages.resolvePackagePath('ide-haskell-hie');
 
-    // Set up the path for the hie-wrapper script.
-    let pluginPath = atom.packages.resolvePackagePath('ide-haskell-hie');
-    let processOptions = {};
+    // If `useHieWrapper` is set to true, set up the path for the hie-wrapper script.
     if (pluginPath && useHieWrapper) {
       hiePath = path.join(pluginPath, 'hie-wrapper.sh');
-      // Get the project path, so we can set it as the CWD of the hie process.
-      let projectPathsCwd = atom.project.getPaths();
-      if (projectPathsCwd.length > 0) {
-        processOptions = { 'cwd': projectPathsCwd[0] };
-      }
+      // We need to set the current working directory, else it will default to the
+      // location of the script.
+      processOptions = { 'cwd': projectPath };
     }
-    // Don't assume any arguments when using a custom wrapper.
-    let args = [''];
+
+    // If both `useCustomHieWrapper` is true and `useCustomHieWrapperPath` contains
+    // a value (the path), then go ahead and set up hie to launch from the custom
+    // wrapper, which also means substituting path placeholders.
     if (useCustomHieWrapper && useCustomHieWrapperPath) {
       hiePath = useCustomHieWrapperPath;
-      let projectPaths = atom.project.getPaths();
-      if (projectPaths.length > 0) {
-        processOptions = { 'cwd': projectPaths[0] };
-        // Expand project placeholders.
-        hiePath = hiePath
-          .replace('${workspaceFolder}', projectPaths[0])
-          .replace('${workspaceRoot}', projectPaths[0]);
-      }
-      // Expand home directory placeholders.
+      processOptions = { 'cwd': projectPath };
+      // Expand project path and $HOME placeholders.
       hiePath = hiePath
+        .replace('${workspaceFolder}', projectPath)
+        .replace('${workspaceRoot}', projectPath)
+        .replace('${projectPath}', projectPath)
         .replace('${HOME}', os.homedir)
         .replace('${home}', os.homedir)
-        .replace('~', os.homedir);
+        .replace(/^~/, os.homedir);
     } else {
+      // Else, if we are launching it directly, add the required arguments.
       args = ['--lsp'];
-      if (hieDebug === true) {
+      if (hieDebug) {
         args.push('--debug', '-l', hieLoggingPath);
       }
     }
 
-    // // Add a command to restart the HIE server.
+    // Add a command to restart the HIE server.
     this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(atom.commands.add('atom-workspace',
       { 'hie:restart-server': () => this.restartServer() })
     );
 
-    const lspServer = childProcess.spawn(hiePath, args, processOptions)
+    // Start the hie process, and assume HIE is not installed, if the launch
+    // fails.
+    const lspServer = childProcess.spawn(hiePath, args, processOptions);
     lspServer.on('error', err => atom.notifications.addError('Unable to start the HIE (Haskell IDE Engine).', {
       dismissable: true,
       buttons: [
@@ -88,10 +104,13 @@ class HaskellLanguageClient extends AutoLanguageClient {
         }
       ],
       description: 'This can occur if you do not hie on your path, or you have yet to install it.'
-    }))
+    }));
     return lspServer;
   }
 
+  /*
+   * Enable the LSP debugging found in Settings -> Core -> Debug LSP.
+   */
   enableDebug(enabled) {
     atom
       .config

--- a/lib/ide-haskell-hie.js
+++ b/lib/ide-haskell-hie.js
@@ -1,7 +1,8 @@
-const childProcess = require('child_process')
-const os = require('os')
-const { shell } = require('electron')
-const { AutoLanguageClient } = require('atom-languageclient')
+const childProcess = require('child_process');
+const os = require('os');
+const { shell } = require('electron');
+const { AutoLanguageClient } = require('atom-languageclient');
+const { CompositeDisposable } = require('atom');
 const path = require('path');
 
 class HaskellLanguageClient extends AutoLanguageClient {

--- a/lib/ide-haskell-hie.js
+++ b/lib/ide-haskell-hie.js
@@ -1,7 +1,7 @@
 const childProcess = require('child_process')
 const os = require('os')
-const {shell} = require('electron')
-const {AutoLanguageClient} = require('atom-languageclient')
+const { shell } = require('electron')
+const { AutoLanguageClient } = require('atom-languageclient')
 const path = require('path');
 
 class HaskellLanguageClient extends AutoLanguageClient {
@@ -19,30 +19,38 @@ class HaskellLanguageClient extends AutoLanguageClient {
     return this.spawnServer()
   }
 
+  restartServer() {
+    this.subscriptions.dispose();
+    atom.notifications.addInfo("HIE is being restarted!");
+    this.restartAllServers();
+  }
+
   spawnServer() {
-    var hiePath = atom.config.get("ide-haskell-hie.hiePath"),
-        useHieWrapper = atom.config.get("ide-haskell-hie.useHieWrapper"),
-        useCustomHieWrapper = atom.config.get("ide-haskell-hie.useCustomHieWrapper"),
-        useCustomHieWrapperPath = atom.config.get("ide-haskell-hie.useCustomHieWrapperPath"),
-        hieDebug = atom.config.get("ide-haskell-hie.isDebug"),
-        hieLoggingPath = atom.config.get("ide-haskell-hie.hieLoggingPath");
+    let hiePath = atom.config.get("ide-haskell-hie.hiePath"),
+      useHieWrapper = atom.config.get("ide-haskell-hie.useHieWrapper"),
+      useCustomHieWrapper = atom.config.get("ide-haskell-hie.useCustomHieWrapper"),
+      useCustomHieWrapperPath = atom.config.get("ide-haskell-hie.useCustomHieWrapperPath"),
+      hieDebug = atom.config.get("ide-haskell-hie.isDebug"),
+      hieLoggingPath = atom.config.get("ide-haskell-hie.hieLoggingPath");
 
     // Set up the path for the hie-wrapper script.
-    var pluginPath = atom.packages.resolvePackagePath('ide-haskell-hie');
-    var processOptions = {};
+    let pluginPath = atom.packages.resolvePackagePath('ide-haskell-hie');
+    let processOptions = {};
     if (pluginPath && useHieWrapper) {
       hiePath = path.join(pluginPath, 'hie-wrapper.sh');
       // Get the project path, so we can set it as the CWD of the hie process.
-      var projectPaths = atom.project.getPaths();
-      if (projectPaths.length > 0) {
-        processOptions = {'cwd': projectPaths[0]};
+      let projectPathsCwd = atom.project.getPaths();
+      if (projectPathsCwd.length > 0) {
+        processOptions = { 'cwd': projectPathsCwd[0] };
       }
     }
+    // Don't assume any arguments when using a custom wrapper.
+    let args = [''];
     if (useCustomHieWrapper && useCustomHieWrapperPath) {
       hiePath = useCustomHieWrapperPath;
-      var projectPaths = atom.project.getPaths();
+      let projectPaths = atom.project.getPaths();
       if (projectPaths.length > 0) {
-        processOptions = {'cwd': projectPaths[0]};
+        processOptions = { 'cwd': projectPaths[0] };
         // Expand project placeholders.
         hiePath = hiePath
           .replace('${workspaceFolder}', projectPaths[0])
@@ -53,14 +61,18 @@ class HaskellLanguageClient extends AutoLanguageClient {
         .replace('${HOME}', os.homedir)
         .replace('${home}', os.homedir)
         .replace('~', os.homedir);
-      // Don't assume any arguments when using a custom wrapper.
-      var args = [''];
     } else {
-      var args = ['--lsp'];
+      args = ['--lsp'];
       if (hieDebug === true) {
         args.push('--debug', '-l', hieLoggingPath);
       }
     }
+
+    // // Add a command to restart the HIE server.
+    this.subscriptions = new CompositeDisposable();
+    this.subscriptions.add(atom.commands.add('atom-workspace',
+      { 'hie:restart-server': () => this.restartServer() })
+    );
 
     const lspServer = childProcess.spawn(hiePath, args, processOptions)
     lspServer.on('error', err => atom.notifications.addError('Unable to start the HIE (Haskell IDE Engine).', {
@@ -76,13 +88,13 @@ class HaskellLanguageClient extends AutoLanguageClient {
       ],
       description: 'This can occur if you do not hie on your path, or you have yet to install it.'
     }))
-    return lspServer
+    return lspServer;
   }
 
   enableDebug(enabled) {
     atom
       .config
-      .set('core.debugLSP', enabled)
+      .set('core.debugLSP', enabled);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "version": "0.9.1",
   "description": "Haskell LSP plugin for HIE (Haskell IDE Engine)",
   "keywords": [],
-  "activationCommands": {},
+  "activationCommands": {
+    "atom-workspace": "hie:restart-server"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:Tehnix/ide-haskell-hie.git"
@@ -28,6 +30,9 @@
     "source.haskell",
     "text.tex.latex.haskell"
   ],
+  "prettier": {
+    "printWidth": 100
+  },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6

--- a/package.json
+++ b/package.json
@@ -3,7 +3,12 @@
   "main": "./lib/ide-haskell-hie",
   "version": "0.9.1",
   "description": "Haskell LSP plugin for HIE (Haskell IDE Engine)",
-  "keywords": [],
+  "keywords": [
+    "haskell",
+    "lsp",
+    "ide",
+    "hie"
+  ],
   "activationCommands": {
     "atom-workspace": "hie:restart-server"
   },
@@ -16,15 +21,15 @@
   },
   "license": "MIT",
   "engines": {
-    "atom": ">=1.21.0 <2.0.0"
+    "atom": ">=1.21.0"
   },
   "dependencies": {
-    "atom-languageclient": "^0.8.3",
+    "atom-languageclient": "^0.9.2",
     "atom-package-deps": "^4.6.1"
   },
   "package-deps": [
-    "atom-ide-ui",
-    "language-haskell"
+    "language-haskell",
+    "atom-ide-ui"
   ],
   "enhancedScopes": [
     "source.haskell",
@@ -97,11 +102,6 @@
         "2.0.0": "consumeLinterV2"
       }
     },
-    "status-bar": {
-      "versions": {
-        "^1.0.0": "consumeStatusBar"
-      }
-    },
     "atom-ide-busy-signal": {
       "versions": {
         "0.1.0": "consumeBusySignal"
@@ -132,11 +132,6 @@
     "definitions": {
       "versions": {
         "0.1.0": "provideDefinitions"
-      }
-    },
-    "hyperclick": {
-      "versions": {
-        "0.1.0": "provideHyperclick"
       }
     },
     "find-references": {


### PR DESCRIPTION
This adds a command to restart HIE, via the command palette cmd+shift+p, and superseeds #17, which was a bit messy in the commits.