### PR TITLE
Improve wrapper to better handle stack projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.0
+* Improve hie-wrapper support for stack projects
+* Pass options to custom wrappers that should be passed to hie
+
 ## 0.10.0
 * Add restart command (accessible from the command palette)
 * Major cleanup in code

--- a/lib/ide-haskell-hie.js
+++ b/lib/ide-haskell-hie.js
@@ -44,8 +44,10 @@ class HaskellLanguageClient extends AutoLanguageClient {
    */
   spawnServer(projectPath) {
     let hiePath = atom.config.get("ide-haskell-hie.hiePath"),
-      processOptions = {},
-      args = [''];
+      // We need to set the current working directory, else it will default to the
+      // location of the script.
+      processOptions = { 'cwd': projectPath },
+      args = ['--lsp'];
     const useHieWrapper = atom.config.get("ide-haskell-hie.useHieWrapper"),
       useCustomHieWrapper = atom.config.get("ide-haskell-hie.useCustomHieWrapper"),
       useCustomHieWrapperPath = atom.config.get("ide-haskell-hie.useCustomHieWrapperPath"),
@@ -53,12 +55,8 @@ class HaskellLanguageClient extends AutoLanguageClient {
       hieLoggingPath = atom.config.get("ide-haskell-hie.hieLoggingPath"),
       pluginPath = atom.packages.resolvePackagePath('ide-haskell-hie');
 
-    // If `useHieWrapper` is set to true, set up the path for the hie-wrapper script.
-    if (pluginPath && useHieWrapper) {
-      hiePath = path.join(pluginPath, 'hie-wrapper.sh');
-      // We need to set the current working directory, else it will default to the
-      // location of the script.
-      processOptions = { 'cwd': projectPath };
+    if (hieDebug) {
+      args.push('--debug', '-l', hieLoggingPath);
     }
 
     // If both `useCustomHieWrapper` is true and `useCustomHieWrapperPath` contains
@@ -66,7 +64,6 @@ class HaskellLanguageClient extends AutoLanguageClient {
     // wrapper, which also means substituting path placeholders.
     if (useCustomHieWrapper && useCustomHieWrapperPath) {
       hiePath = useCustomHieWrapperPath;
-      processOptions = { 'cwd': projectPath };
       // Expand project path and $HOME placeholders.
       hiePath = hiePath
         .replace('${workspaceFolder}', projectPath)
@@ -75,12 +72,9 @@ class HaskellLanguageClient extends AutoLanguageClient {
         .replace('${HOME}', os.homedir)
         .replace('${home}', os.homedir)
         .replace(/^~/, os.homedir);
-    } else {
-      // Else, if we are launching it directly, add the required arguments.
-      args = ['--lsp'];
-      if (hieDebug) {
-        args.push('--debug', '-l', hieLoggingPath);
-      }
+    } else if (pluginPath && useHieWrapper) {
+      // If `useHieWrapper` is set to true, set up the path for the hie-wrapper script.
+      hiePath = path.join(pluginPath, 'hie-wrapper.sh');
     }
 
     // Add a command to restart the HIE server.

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
       "order": 2,
       "type": "boolean",
       "default": false,
-      "description": "Automatically try to select a hie version that matches the GHC version of the project (overwrites the hie path)"
+      "description": "Automatically try to select a hie version that matches the GHC version of the project, and enable additional support for stack projects (overwrites the hie path)."
     },
     "useCustomHieWrapper": {
       "title": "Use a custom hie wrapper",


### PR DESCRIPTION
The existing wrapper code performs some basic detection of stack projects, but does not handle `hie` installed using `stack build --copy-compiler-tool` unless atom is started using `stack exec -- atom`. This PR adjusts the wrapper script to launch `hie` using `stack exec` when a stack project is detected, with the added benefit of ensuring all executables on the project’s path are on the PATH when hie runs.

Additionally, this PR makes some minor changes to the way custom wrappers are handled, treating them closer to the way the default wrapper is handled. Primarily, this means passing the actual arguments that should be passed to HIE instead of passing a single empty string argument (which is not terribly useful).