### PR TITLE
wrapper: Pass HIE_HOOGLE_DATABASE when available from stack

### DIFF
--- a/hie-wrapper.sh
+++ b/hie-wrapper.sh
@@ -3,8 +3,9 @@ DEBUG=1
 indent=""
 function debug {
   if [[ $DEBUG == 1 ]]; then
-    echo "$indent" "$@" >> /tmp/hie-wrapper.log
-  fi
+    printf '%s' "$indent"
+    echo "$@"
+  fi >> /tmp/hie-wrapper.log
 }
 
 curDir=`pwd`
@@ -87,6 +88,31 @@ else
   error_message='{"jsonrpc":"2.0","id":1,"error":{"code":-32099,"message":"Cannot find hie in the path"}}'
   printf 'Content-Length: %s\r\n\r\n%s' ${#error_message} "$error_message"
   exit 1
+fi
+
+if [[ -n $USE_STACK ]]; then
+  debug 'Checking if a stack-managed Hoogle database exists'
+  indent='    '
+  # try to find the project's Hoogle database. --local-hoogle-root is
+  # only available on Stack 2.x+, so just try it and see if it succeeds.
+  if hoogle_root=$(stack path --local-hoogle-root 2>/dev/null) \
+      && [[ -n $hoogle_root ]]; then
+    hoogle_database="$hoogle_root/database.hoo"
+    # don't bother setting HIE_HOOGLE_DATABASE unless a local database
+    # has actually been built (so someone can set it themselves to a
+    # more global database if they want)
+    if [[ -f $hoogle_database ]]; then
+      debug "Using Hoogle database at $hoogle_database"
+      export HIE_HOOGLE_DATABASE=$hoogle_database
+    else
+      debug "No Hoogle database exists at $hoogle_database"
+      debug 'continuing without setting HIE_HOOGLE_DATABASE'
+    fi
+  else
+    debug '`stack path --local-hoogle-root` failed (maybe `stack` is too old?)'
+    debug 'continuing without setting HIE_HOOGLE_DATABASE'
+  fi
+  indent='  '
 fi
 
 debug "Starting HIE"


### PR DESCRIPTION
Recent versions of `stack` make it easy to access the path to the project-local Hoogle database, so this adjusts the wrapper script to automatically pass that through to `hie` via the appropriate environment variable.